### PR TITLE
Add Dropbox client integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     compileOnly libs.jetbrains.annotations
+    implementation libs.dropbox.sdk
     implementation libs.logback.classic
     implementation libs.metadata.extractor
     implementation libs.slf4j.api

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation libs.logback.classic
     implementation libs.metadata.extractor
     implementation libs.slf4j.api
+    testImplementation libs.bundles.mockito.all
     testImplementation platform(libs.junit.bom)
     testImplementation libs.junit.jupiter
     testRuntimeOnly libs.junit.launcher

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ jetbrains-annotations = "26.0.1"
 junit-bom = "5.11.3"
 logback-classic = "1.5.12"
 metadata-extractor = "2.19.0"
+mockito = "5.14.1"
 slf4j-api = "2.0.16"
 
 [libraries]
@@ -14,4 +15,9 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
 metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadata-extractor"}
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }
+
+[bundles]
+mockito-all = ["mockito-core", "mockito-junit"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+dropbox-sdk = "7.0.0"
 jetbrains-annotations = "26.0.1"
 junit-bom = "5.11.3"
 logback-classic = "1.5.12"
@@ -6,6 +7,7 @@ metadata-extractor = "2.19.0"
 slf4j-api = "2.0.16"
 
 [libraries]
+dropbox-sdk = { module = "com.dropbox.core:dropbox-core-sdk", version.ref = "dropbox-sdk" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/src/main/java/io/huangsam/photohaul/Main.java
+++ b/src/main/java/io/huangsam/photohaul/Main.java
@@ -3,10 +3,10 @@ package io.huangsam.photohaul;
 import java.nio.file.Files;
 import java.util.List;
 
+import io.huangsam.photohaul.migration.MigratorFactory;
 import io.huangsam.photohaul.migration.PhotoFunction;
 import io.huangsam.photohaul.migration.PhotoResolver;
 import io.huangsam.photohaul.migration.Migrator;
-import io.huangsam.photohaul.migration.PathMigrator;
 import io.huangsam.photohaul.traversal.PathRule;
 import io.huangsam.photohaul.traversal.PathRuleSet;
 import io.huangsam.photohaul.traversal.PathTraversal;
@@ -32,7 +32,8 @@ public class Main {
 
         PhotoResolver photoResolver = new PhotoResolver(List.of(PhotoFunction.yearTaken()));
 
-        Migrator migrator = new PathMigrator(SETTINGS.getTargetRootPath(), photoResolver);
+        MigratorFactory migratorFactory = new MigratorFactory();
+        Migrator migrator = migratorFactory.pathInstance(SETTINGS, photoResolver);
         migrator.migratePhotos(pathVisitor.getPhotos());
 
         LOG.info("Finish with success={} failure={}", migrator.getSuccessCount(), migrator.getFailureCount());

--- a/src/main/java/io/huangsam/photohaul/Main.java
+++ b/src/main/java/io/huangsam/photohaul/Main.java
@@ -1,8 +1,6 @@
 package io.huangsam.photohaul;
 
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import io.huangsam.photohaul.migration.PhotoFunction;
@@ -32,10 +30,9 @@ public class Main {
         PathTraversal pathTraversal = new PathTraversal(SETTINGS.getSourceRootPath(), pathRuleSet);
         pathTraversal.traverse(pathVisitor);
 
-        CopyOption copyOption = StandardCopyOption.REPLACE_EXISTING;
         PhotoResolver photoResolver = new PhotoResolver(List.of(PhotoFunction.yearTaken()));
 
-        Migrator migrator = new PathMigrator(SETTINGS.getTargetRootPath(), copyOption, photoResolver);
+        Migrator migrator = new PathMigrator(SETTINGS.getTargetRootPath(), photoResolver);
         migrator.migratePhotos(pathVisitor.getPhotos());
 
         LOG.info("Finish with success={} failure={}", migrator.getSuccessCount(), migrator.getFailureCount());

--- a/src/main/java/io/huangsam/photohaul/Main.java
+++ b/src/main/java/io/huangsam/photohaul/Main.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.util.List;
 
 import io.huangsam.photohaul.migration.MigratorFactory;
+import io.huangsam.photohaul.migration.MigratorMode;
 import io.huangsam.photohaul.migration.PhotoFunction;
 import io.huangsam.photohaul.migration.PhotoResolver;
 import io.huangsam.photohaul.migration.Migrator;
@@ -30,10 +31,11 @@ public class Main {
         PathTraversal pathTraversal = new PathTraversal(SETTINGS.getSourceRootPath(), pathRuleSet);
         pathTraversal.traverse(pathVisitor);
 
+        MigratorMode migratorMode = MigratorMode.PATH;
         PhotoResolver photoResolver = new PhotoResolver(List.of(PhotoFunction.yearTaken()));
 
         MigratorFactory migratorFactory = new MigratorFactory();
-        Migrator migrator = migratorFactory.pathInstance(SETTINGS, photoResolver);
+        Migrator migrator = migratorFactory.make(migratorMode, SETTINGS, photoResolver);
         migrator.migratePhotos(pathVisitor.getPhotos());
 
         LOG.info("Finish with success={} failure={}", migrator.getSuccessCount(), migrator.getFailureCount());

--- a/src/main/java/io/huangsam/photohaul/Main.java
+++ b/src/main/java/io/huangsam/photohaul/Main.java
@@ -29,13 +29,13 @@ public class Main {
                 PathRule.validExtensions().or(PathRule.isImageContent()),
                 PathRule.minimumBytes(100L)));
 
-        PathTraversal pathTraversal = new PathTraversal(SETTINGS.getSourceRoot(), pathRuleSet);
+        PathTraversal pathTraversal = new PathTraversal(SETTINGS.getSourceRootPath(), pathRuleSet);
         pathTraversal.traverse(pathVisitor);
 
         CopyOption copyOption = StandardCopyOption.REPLACE_EXISTING;
         PhotoResolver photoResolver = new PhotoResolver(List.of(PhotoFunction.yearTaken()));
 
-        Migrator migrator = new PathMigrator(SETTINGS.getTargetRoot(), copyOption, photoResolver);
+        Migrator migrator = new PathMigrator(SETTINGS.getTargetRootPath(), copyOption, photoResolver);
         migrator.migratePhotos(pathVisitor.getPhotos());
 
         LOG.info("Finish with success={} failure={}", migrator.getSuccessCount(), migrator.getFailureCount());

--- a/src/main/java/io/huangsam/photohaul/Settings.java
+++ b/src/main/java/io/huangsam/photohaul/Settings.java
@@ -1,9 +1,12 @@
 package io.huangsam.photohaul;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.Properties;
 
 public class Settings {
@@ -18,19 +21,15 @@ public class Settings {
         }
     }
 
+    public String getValue(@NotNull String key) {
+        return Objects.requireNonNull(properties.getProperty(key));
+    }
+
     public Path getSourceRootPath() {
-        String sourceRoot = properties.getProperty("source.root");
-        if (sourceRoot == null) {
-            throw new IllegalArgumentException("Missing source root");
-        }
-        return Paths.get(System.getProperty("user.home")).resolve(sourceRoot);
+        return Paths.get(System.getProperty("user.home")).resolve(getValue("source.root"));
     }
 
     public Path getTargetRootPath() {
-        String targetRoot = properties.getProperty("target.root");
-        if (targetRoot == null) {
-            throw new IllegalArgumentException("Missing target root");
-        }
-        return Paths.get(System.getProperty("user.home")).resolve(targetRoot);
+        return Paths.get(System.getProperty("user.home")).resolve(getValue("target.root"));
     }
 }

--- a/src/main/java/io/huangsam/photohaul/Settings.java
+++ b/src/main/java/io/huangsam/photohaul/Settings.java
@@ -1,15 +1,19 @@
 package io.huangsam.photohaul;
 
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 import java.util.Properties;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class Settings {
+    private static final Logger LOG = getLogger(Settings.class);
+
     private final Properties properties;
 
     public Settings(String name) {
@@ -22,7 +26,12 @@ public class Settings {
     }
 
     public String getValue(@NotNull String key) {
-        return Objects.requireNonNull(properties.getProperty(key));
+        String value = properties.getProperty(key);
+        if (value == null) {
+            LOG.error("Cannot find setting {}", key);
+            throw new NullPointerException();
+        }
+        return value;
     }
 
     public Path getSourceRootPath() {

--- a/src/main/java/io/huangsam/photohaul/Settings.java
+++ b/src/main/java/io/huangsam/photohaul/Settings.java
@@ -18,7 +18,7 @@ public class Settings {
         }
     }
 
-    public Path getSourceRoot() {
+    public Path getSourceRootPath() {
         String sourceRoot = properties.getProperty("source.root");
         if (sourceRoot == null) {
             throw new IllegalArgumentException("Missing source root");
@@ -26,7 +26,7 @@ public class Settings {
         return Paths.get(System.getProperty("user.home")).resolve(sourceRoot);
     }
 
-    public Path getTargetRoot() {
+    public Path getTargetRootPath() {
         String targetRoot = properties.getProperty("target.root");
         if (targetRoot == null) {
             throw new IllegalArgumentException("Missing target root");

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -2,6 +2,7 @@ package io.huangsam.photohaul.migration;
 
 import com.dropbox.core.v2.DbxClientV2;
 import io.huangsam.photohaul.model.Photo;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import java.util.Collection;
@@ -11,19 +12,21 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class DropboxMigrator implements Migrator {
     private static final Logger LOG = getLogger(DropboxMigrator.class);
 
+    private final String targetRoot;
     private final DbxClientV2 dropboxClient;
     private final PhotoResolver photoResolver;
 
     private long successCount = 0L;
     private long failureCount = 0L;
 
-    public DropboxMigrator(DbxClientV2 dropboxClient, PhotoResolver photoResolver) {
+    public DropboxMigrator(String targetRoot, DbxClientV2 dropboxClient, PhotoResolver photoResolver) {
+        this.targetRoot = targetRoot;
         this.dropboxClient = dropboxClient;
         this.photoResolver = photoResolver;
     }
 
     @Override
-    public void migratePhotos(Collection<Photo> photos) {
+    public void migratePhotos(@NotNull Collection<Photo> photos) {
 
     }
 

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -37,6 +37,7 @@ public class DropboxMigrator implements Migrator {
             try {
                 LOG.trace("Move {} to {}", photo.name(), targetPath);
                 try (InputStream in = Files.newInputStream(photo.path())) {
+                    dropboxClient.files().createFolderV2(targetPath);
                     dropboxClient.files()
                             .uploadBuilder(targetPath + "/" + photo.name())
                             .uploadAndFinish(in);

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -2,7 +2,6 @@ package io.huangsam.photohaul.migration;
 
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
-import com.dropbox.core.v2.files.CreateFolderErrorException;
 import com.dropbox.core.v2.files.DbxUserFilesRequests;
 import io.huangsam.photohaul.model.Photo;
 import org.jetbrains.annotations.NotNull;
@@ -44,14 +43,8 @@ public class DropboxMigrator implements Migrator {
                 }
                 requests.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);
                 successCount++;
-            } catch (IOException e) {
-                LOG.error("Cannot move {} with I/O error: {}", photo.name(), e.getMessage());
-                failureCount++;
-            } catch (CreateFolderErrorException e) {
-                LOG.error("Cannot move {} with DBX folder error: {}", photo.name(), e.getMessage());
-                failureCount++;
-            } catch (DbxException e) {
-                LOG.error("Cannot move {} with DBX general error: {}", photo.name(), e.getMessage());
+            } catch (IOException | DbxException e) {
+                LOG.error("Cannot move {}: {}", photo.name(), e.getMessage());
                 failureCount++;
             }
         });

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -36,14 +36,12 @@ public class DropboxMigrator implements Migrator {
         DbxUserFilesRequests requests = dropboxClient.files();
         photos.forEach(photo -> {
             String targetPath = getTargetPath(photo);
-            try {
-                LOG.trace("Move {} to {}", photo.name(), targetPath);
-                try (InputStream in = Files.newInputStream(photo.path())) {
-                    if (requests.getMetadata(targetPath) == null) {
-                        requests.createFolderV2(targetPath);
-                    }
-                    requests.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);
+            LOG.trace("Move {} to {}", photo.name(), targetPath);
+            try (InputStream in = Files.newInputStream(photo.path())) {
+                if (requests.getMetadata(targetPath) == null) {
+                    requests.createFolderV2(targetPath);
                 }
+                requests.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);
                 successCount++;
             } catch (IOException | DbxException e) {
                 LOG.error("Cannot move {}: {}", photo.name(), e.getMessage());

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -33,16 +33,16 @@ public class DropboxMigrator implements Migrator {
     @Override
     public void migratePhotos(@NotNull Collection<Photo> photos) {
         LOG.debug("Start migration to {}", targetRoot);
-        DbxUserFilesRequests requester = dropboxClient.files();
+        DbxUserFilesRequests requests = dropboxClient.files();
         photos.forEach(photo -> {
             String targetPath = getTargetPath(photo);
             try {
                 LOG.trace("Move {} to {}", photo.name(), targetPath);
                 try (InputStream in = Files.newInputStream(photo.path())) {
-                    if (requester.getMetadata(targetPath) == null) {
-                        requester.createFolderV2(targetPath);
+                    if (requests.getMetadata(targetPath) == null) {
+                        requests.createFolderV2(targetPath);
                     }
-                    requester.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);
+                    requests.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);
                 }
                 successCount++;
             } catch (IOException | DbxException e) {

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -29,11 +29,11 @@ public class DropboxMigrator implements Migrator {
 
     @Override
     public long getSuccessCount() {
-        return 0L;
+        return successCount;
     }
 
     @Override
     public long getFailureCount() {
-        return 0L;
+        return failureCount;
     }
 }

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -43,7 +43,7 @@ public class DropboxMigrator implements Migrator {
                 }
                 successCount++;
             } catch (IOException | DbxException e) {
-                LOG.warn("Cannot move {}: {}", photo.name(), e.getMessage());
+                LOG.error("Cannot move {}: {}", photo.name(), e.getMessage());
                 failureCount++;
             }
         });

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -1,0 +1,22 @@
+package io.huangsam.photohaul.migration;
+
+import io.huangsam.photohaul.model.Photo;
+
+import java.util.Collection;
+
+public class DropboxMigrator implements Migrator {
+    @Override
+    public void migratePhotos(Collection<Photo> photos) {
+
+    }
+
+    @Override
+    public long getSuccessCount() {
+        return 0L;
+    }
+
+    @Override
+    public long getFailureCount() {
+        return 0L;
+    }
+}

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -1,10 +1,27 @@
 package io.huangsam.photohaul.migration;
 
+import com.dropbox.core.v2.DbxClientV2;
 import io.huangsam.photohaul.model.Photo;
+import org.slf4j.Logger;
 
 import java.util.Collection;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class DropboxMigrator implements Migrator {
+    private static final Logger LOG = getLogger(DropboxMigrator.class);
+
+    private final DbxClientV2 dropboxClient;
+    private final PhotoResolver photoResolver;
+
+    private long successCount = 0L;
+    private long failureCount = 0L;
+
+    public DropboxMigrator(DbxClientV2 dropboxClient, PhotoResolver photoResolver) {
+        this.dropboxClient = dropboxClient;
+        this.photoResolver = photoResolver;
+    }
+
     @Override
     public void migratePhotos(Collection<Photo> photos) {
 

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -1,10 +1,14 @@
 package io.huangsam.photohaul.migration;
 
+import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import io.huangsam.photohaul.model.Photo;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -19,15 +23,30 @@ public class DropboxMigrator implements Migrator {
     private long successCount = 0L;
     private long failureCount = 0L;
 
-    public DropboxMigrator(String targetRoot, DbxClientV2 dropboxClient, PhotoResolver photoResolver) {
-        this.targetRoot = targetRoot;
-        this.dropboxClient = dropboxClient;
-        this.photoResolver = photoResolver;
+    public DropboxMigrator(String target, DbxClientV2 client, PhotoResolver resolver) {
+        targetRoot = target;
+        dropboxClient = client;
+        photoResolver = resolver;
     }
 
     @Override
     public void migratePhotos(@NotNull Collection<Photo> photos) {
-
+        LOG.debug("Start migration to {}", targetRoot);
+        photos.forEach(photo -> {
+            String targetPath = getTargetPath(photo);
+            try {
+                LOG.trace("Move {} to {}", photo.name(), targetPath);
+                try (InputStream in = Files.newInputStream(photo.path())) {
+                    dropboxClient.files()
+                            .uploadBuilder(targetPath + "/" + photo.name())
+                            .uploadAndFinish(in);
+                }
+                successCount++;
+            } catch (IOException | DbxException e) {
+                LOG.warn("Cannot move {}: {}", photo.name(), e.getMessage());
+                failureCount++;
+            }
+        });
     }
 
     @Override
@@ -38,5 +57,17 @@ public class DropboxMigrator implements Migrator {
     @Override
     public long getFailureCount() {
         return failureCount;
+    }
+
+    private String getTargetPath(Photo photo) {
+        try {
+            StringBuilder result = new StringBuilder(targetRoot);
+            for (String out : photoResolver.resolveList(photo)) {
+                result.append("/").append(out);
+            }
+            return result.toString();
+        } catch (NullPointerException e) {
+            return targetRoot + "/Other";
+        }
     }
 }

--- a/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/DropboxMigrator.java
@@ -3,6 +3,7 @@ package io.huangsam.photohaul.migration;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.DbxUserFilesRequests;
+import com.dropbox.core.v2.files.ListFolderResult;
 import io.huangsam.photohaul.model.Photo;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -38,7 +39,8 @@ public class DropboxMigrator implements Migrator {
             String targetPath = getTargetPath(photo);
             LOG.trace("Move {} to {}", photo.name(), targetPath);
             try (InputStream in = Files.newInputStream(photo.path())) {
-                if (requests.getMetadata(targetPath) == null) {
+                ListFolderResult result = requests.listFolder(targetPath);
+                if (result.getEntries().isEmpty()) {
                     requests.createFolderV2(targetPath);
                 }
                 requests.uploadBuilder(targetPath + "/" + photo.name()).uploadAndFinish(in);

--- a/src/main/java/io/huangsam/photohaul/migration/Migrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/Migrator.java
@@ -1,6 +1,7 @@
 package io.huangsam.photohaul.migration;
 
 import io.huangsam.photohaul.model.Photo;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
@@ -18,7 +19,7 @@ public interface Migrator {
      *
      * @param photos Collection of photo records
      */
-    void migratePhotos(Collection<Photo> photos);
+    void migratePhotos(@NotNull Collection<Photo> photos);
 
     /**
      * Get success count.

--- a/src/main/java/io/huangsam/photohaul/migration/MigratorFactory.java
+++ b/src/main/java/io/huangsam/photohaul/migration/MigratorFactory.java
@@ -3,13 +3,23 @@ package io.huangsam.photohaul.migration;
 import com.dropbox.core.DbxRequestConfig;
 import com.dropbox.core.v2.DbxClientV2;
 import io.huangsam.photohaul.Settings;
+import org.jetbrains.annotations.NotNull;
 
 public class MigratorFactory {
-    public PathMigrator pathInstance(Settings settings, PhotoResolver resolver) {
+    public Migrator make(@NotNull MigratorMode mode, Settings settings, PhotoResolver resolver) {
+        return switch (mode) {
+            case PATH -> pathInstance(settings, resolver);
+            case DROPBOX -> dropboxInstance(settings, resolver);
+        };
+    }
+
+    @NotNull
+    private PathMigrator pathInstance(@NotNull Settings settings, PhotoResolver resolver) {
         return new PathMigrator(settings.getTargetRootPath(), resolver);
     }
 
-    public DropboxMigrator dropboxInstance(Settings settings, PhotoResolver resolver) {
+    @NotNull
+    private DropboxMigrator dropboxInstance(@NotNull Settings settings, PhotoResolver resolver) {
         String target = settings.getValue("target.root");
         DbxRequestConfig config = DbxRequestConfig.newBuilder(settings.getValue("dbx.clientId")).build();
         DbxClientV2 client = new DbxClientV2(config, settings.getValue("dbx.accessToken"));

--- a/src/main/java/io/huangsam/photohaul/migration/MigratorFactory.java
+++ b/src/main/java/io/huangsam/photohaul/migration/MigratorFactory.java
@@ -1,0 +1,18 @@
+package io.huangsam.photohaul.migration;
+
+import com.dropbox.core.DbxRequestConfig;
+import com.dropbox.core.v2.DbxClientV2;
+import io.huangsam.photohaul.Settings;
+
+public class MigratorFactory {
+    public PathMigrator pathInstance(Settings settings, PhotoResolver resolver) {
+        return new PathMigrator(settings.getTargetRootPath(), resolver);
+    }
+
+    public DropboxMigrator dropboxInstance(Settings settings, PhotoResolver resolver) {
+        String target = settings.getValue("target.root");
+        DbxRequestConfig config = DbxRequestConfig.newBuilder(settings.getValue("dbx.clientId")).build();
+        DbxClientV2 client = new DbxClientV2(config, settings.getValue("dbx.accessToken"));
+        return new DropboxMigrator(target, client, resolver);
+    }
+}

--- a/src/main/java/io/huangsam/photohaul/migration/MigratorMode.java
+++ b/src/main/java/io/huangsam/photohaul/migration/MigratorMode.java
@@ -1,0 +1,6 @@
+package io.huangsam.photohaul.migration;
+
+public enum MigratorMode {
+    PATH,
+    DROPBOX
+}

--- a/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
@@ -5,9 +5,9 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collection;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -16,15 +16,13 @@ public class PathMigrator implements Migrator {
     private static final Logger LOG = getLogger(PathMigrator.class);
 
     protected final Path targetRoot;
-    private final CopyOption copyOption;
     private final PhotoResolver photoResolver;
 
     private long successCount = 0L;
     private long failureCount = 0L;
 
-    public PathMigrator(Path target, CopyOption option, PhotoResolver resolver) {
+    public PathMigrator(Path target, PhotoResolver resolver) {
         targetRoot = target;
-        copyOption = option;
         photoResolver = resolver;
     }
 
@@ -36,7 +34,7 @@ public class PathMigrator implements Migrator {
             LOG.trace("Move {} to {}", photo.name(), targetPath);
             try {
                 Files.createDirectories(targetPath);
-                Files.move(photo.path(), targetPath.resolve(photo.name()), copyOption);
+                Files.move(photo.path(), targetPath.resolve(photo.name()), StandardCopyOption.REPLACE_EXISTING);
                 successCount++;
             } catch (IOException e) {
                 LOG.error("Cannot move {}: {}", photo.name(), e.getMessage());

--- a/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
@@ -30,7 +30,7 @@ public class PathMigrator implements Migrator {
 
     @Override
     public final void migratePhotos(@NotNull Collection<Photo> photos) {
-        LOG.debug("Start migration to {}", targetRoot);
+        LOG.debug("Start path migration to {}", targetRoot);
         photos.forEach(photo -> {
             Path targetPath = getTargetPath(photo);
             LOG.trace("Move {} to {}", photo.name(), targetPath);

--- a/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
@@ -39,7 +39,7 @@ public class PathMigrator implements Migrator {
                 Files.move(photo.path(), targetPath.resolve(photo.name()), copyOption);
                 successCount++;
             } catch (IOException e) {
-                LOG.warn("Cannot move {}: {}", photo.name(), e.getMessage());
+                LOG.error("Cannot move {}: {}", photo.name(), e.getMessage());
                 failureCount++;
             }
         });

--- a/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
@@ -22,10 +22,10 @@ public class PathMigrator implements Migrator {
     private long successCount = 0L;
     private long failureCount = 0L;
 
-    public PathMigrator(Path targetRoot, CopyOption copyOption, PhotoResolver photoResolver) {
-        this.targetRoot = targetRoot;
-        this.copyOption = copyOption;
-        this.photoResolver = photoResolver;
+    public PathMigrator(Path target, CopyOption option, PhotoResolver resolver) {
+        targetRoot = target;
+        copyOption = option;
+        photoResolver = resolver;
     }
 
     @Override

--- a/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
+++ b/src/main/java/io/huangsam/photohaul/migration/PathMigrator.java
@@ -33,8 +33,8 @@ public class PathMigrator implements Migrator {
         LOG.debug("Start migration to {}", targetRoot);
         photos.forEach(photo -> {
             Path targetPath = getTargetPath(photo);
+            LOG.trace("Move {} to {}", photo.name(), targetPath);
             try {
-                LOG.trace("Move {} to {}", photo.name(), targetPath);
                 Files.createDirectories(targetPath);
                 Files.move(photo.path(), targetPath.resolve(photo.name()), copyOption);
                 successCount++;

--- a/src/main/resources/dbx-example.properties
+++ b/src/main/resources/dbx-example.properties
@@ -1,0 +1,4 @@
+source.root=Dummy/Source
+target.root=/Demo/Target
+dbx.clientId=Photohaul/1.0
+dbx.accessToken=Replace this with real token

--- a/src/main/resources/dbx-example.properties
+++ b/src/main/resources/dbx-example.properties
@@ -1,4 +1,11 @@
+# Source path on local to visit photos
 source.root=Dummy/Source
+
+# Target path on Dropbox to upload photos
 target.root=/Demo/Target
+
+# Anything you want it to be! Here is an example below
 dbx.clientId=Photohaul/1.0
+
+# Generated from the App Console
 dbx.accessToken=Replace this with real token

--- a/src/main/resources/path-example.properties
+++ b/src/main/resources/path-example.properties
@@ -1,2 +1,5 @@
+# Source path on local to visit photos
 source.root=Dummy/Source
+
+# Target path on local to upload photos
 target.root=Dummy/Target

--- a/src/test/java/io/huangsam/photohaul/TestPathBase.java
+++ b/src/test/java/io/huangsam/photohaul/TestPathBase.java
@@ -1,6 +1,9 @@
 package io.huangsam.photohaul;
 
+import io.huangsam.photohaul.traversal.PhotoPathVisitor;
+
 import java.nio.file.Path;
+import java.util.List;
 
 public abstract class TestPathBase {
     private static final Path TEST_RESOURCES = Path.of("src/test/resources");
@@ -11,5 +14,13 @@ public abstract class TestPathBase {
 
     protected static Path getTempResources() {
         return TEST_RESOURCES.resolve("temp");
+    }
+
+    protected static PhotoPathVisitor visitor(Path path, List<String> names) {
+        PhotoPathVisitor pathVisitor = new PhotoPathVisitor();
+        for (String name : names) {
+            pathVisitor.visitPhoto(path.resolve(name));
+        }
+        return pathVisitor;
     }
 }

--- a/src/test/java/io/huangsam/photohaul/TestSettings.java
+++ b/src/test/java/io/huangsam/photohaul/TestSettings.java
@@ -8,12 +8,12 @@ public class TestSettings {
     private static final Settings SETTINGS = new Settings("path-example.properties");
 
     @Test
-    void testGetSourceRoot() {
-        assertTrue(SETTINGS.getSourceRoot().endsWith("Dummy/Source"));
+    void testGetSourceRootPath() {
+        assertTrue(SETTINGS.getSourceRootPath().endsWith("Dummy/Source"));
     }
 
     @Test
-    void testGetTargetRoot() {
-        assertTrue(SETTINGS.getTargetRoot().endsWith("Dummy/Target"));
+    void testGetTargetRootPath() {
+        assertTrue(SETTINGS.getTargetRootPath().endsWith("Dummy/Target"));
     }
 }

--- a/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
@@ -40,10 +40,10 @@ public class TestDropboxMigrator extends TestPathBase {
 
         List<String> names = List.of("bauerlite.jpg", "salad.jpg", "foobar.jpg");
         PhotoPathVisitor pathVisitor = visitor(getStaticResources(), names);
-        DropboxMigrator dbxMigrator = new DropboxMigrator("/Foo", clientMock, new PhotoResolver(List.of()));
-        dbxMigrator.migratePhotos(pathVisitor.getPhotos());
+        DropboxMigrator migrator = new DropboxMigrator("/Foo", clientMock, new PhotoResolver(List.of()));
+        migrator.migratePhotos(pathVisitor.getPhotos());
 
-        assertEquals(2, dbxMigrator.getSuccessCount());
-        assertEquals(1, dbxMigrator.getFailureCount());
+        assertEquals(2, migrator.getSuccessCount());
+        assertEquals(1, migrator.getFailureCount());
     }
 }

--- a/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,13 +45,5 @@ public class TestDropboxMigrator extends TestPathBase {
 
         assertEquals(2, dbxMigrator.getSuccessCount());
         assertEquals(1, dbxMigrator.getFailureCount());
-    }
-
-    private static PhotoPathVisitor visitor(Path path, List<String> names) {
-        PhotoPathVisitor pathVisitor = new PhotoPathVisitor();
-        for (String name : names) {
-            pathVisitor.visitPhoto(path.resolve(name));
-        }
-        return pathVisitor;
     }
 }

--- a/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
@@ -38,6 +38,7 @@ public class TestDropboxMigrator extends TestPathBase {
         when(clientMock.files()).thenReturn(requestsMock);
         when(requestsMock.listFolder(any())).thenReturn(folderResultMock);
         when(requestsMock.uploadBuilder(any())).thenReturn(uploadBuilderMock);
+
         List<String> names = List.of("bauerlite.jpg", "salad.jpg", "foobar.jpg");
         PhotoPathVisitor pathVisitor = visitor(getStaticResources(), names);
         DropboxMigrator dbxMigrator = new DropboxMigrator("/Foo", clientMock, new PhotoResolver(List.of()));

--- a/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestDropboxMigrator.java
@@ -1,0 +1,57 @@
+package io.huangsam.photohaul.migration;
+
+import com.dropbox.core.DbxException;
+import com.dropbox.core.v2.DbxClientV2;
+import com.dropbox.core.v2.files.DbxUserFilesRequests;
+import com.dropbox.core.v2.files.ListFolderResult;
+import com.dropbox.core.v2.files.UploadBuilder;
+import io.huangsam.photohaul.TestPathBase;
+import io.huangsam.photohaul.traversal.PhotoPathVisitor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestDropboxMigrator extends TestPathBase {
+    @Mock
+    DbxClientV2 clientMock;
+
+    @Mock
+    DbxUserFilesRequests requestsMock;
+
+    @Mock
+    ListFolderResult folderResultMock;
+
+    @Mock
+    UploadBuilder uploadBuilderMock;
+
+    @Test
+    void testMigratePhotos() throws DbxException {
+        when(clientMock.files()).thenReturn(requestsMock);
+        when(requestsMock.listFolder(any())).thenReturn(folderResultMock);
+        when(requestsMock.uploadBuilder(any())).thenReturn(uploadBuilderMock);
+        List<String> names = List.of("bauerlite.jpg", "salad.jpg", "foobar.jpg");
+        PhotoPathVisitor pathVisitor = visitor(getStaticResources(), names);
+        DropboxMigrator dbxMigrator = new DropboxMigrator("/Foo", clientMock, new PhotoResolver(List.of()));
+        dbxMigrator.migratePhotos(pathVisitor.getPhotos());
+
+        assertEquals(2, dbxMigrator.getSuccessCount());
+        assertEquals(1, dbxMigrator.getFailureCount());
+    }
+
+    private static PhotoPathVisitor visitor(Path path, List<String> names) {
+        PhotoPathVisitor pathVisitor = new PhotoPathVisitor();
+        for (String name : names) {
+            pathVisitor.visitPhoto(path.resolve(name));
+        }
+        return pathVisitor;
+    }
+}

--- a/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
@@ -30,14 +30,6 @@ public class TestPathMigrator extends TestPathBase {
         pathMigrator.migratePhotos(pathVisitor.getPhotos());
     }
 
-    private static PhotoPathVisitor visitor(Path path, List<String> names) {
-        PhotoPathVisitor pathVisitor = new PhotoPathVisitor();
-        for (String name : names) {
-            pathVisitor.visitPhoto(path.resolve(name));
-        }
-        return pathVisitor;
-    }
-
     private static PathMigrator migrator(Path path) {
         return new PathMigrator(path, new PhotoResolver(List.of()));
     }

--- a/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
@@ -5,7 +5,6 @@ import io.huangsam.photohaul.traversal.PhotoPathVisitor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,22 +14,18 @@ public class TestPathMigrator extends TestPathBase {
     void testMigratePhotos() {
         List<String> names = List.of("bauerlite.jpg", "salad.jpg", "foobar.jpg");
         PhotoPathVisitor pathVisitor = visitor(getStaticResources(), names);
-        PathMigrator pathMigrator = migrator(getTempResources());
-        pathMigrator.migratePhotos(pathVisitor.getPhotos());
+        PathMigrator migrator = new PathMigrator(getTempResources(), new PhotoResolver(List.of()));
+        migrator.migratePhotos(pathVisitor.getPhotos());
 
-        assertEquals(2, pathMigrator.getSuccessCount());
-        assertEquals(1, pathMigrator.getFailureCount());
+        assertEquals(2, migrator.getSuccessCount());
+        assertEquals(1, migrator.getFailureCount());
     }
 
     @AfterAll
     static void tearDown() {
         List<String> names = List.of("bauerlite.jpg", "salad.jpg");
         PhotoPathVisitor pathVisitor = visitor(getTempResources(), names);
-        PathMigrator pathMigrator = migrator(getStaticResources());
+        PathMigrator pathMigrator = new PathMigrator(getStaticResources(), new PhotoResolver(List.of()));
         pathMigrator.migratePhotos(pathVisitor.getPhotos());
-    }
-
-    private static PathMigrator migrator(Path path) {
-        return new PathMigrator(path, new PhotoResolver(List.of()));
     }
 }

--- a/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
+++ b/src/test/java/io/huangsam/photohaul/migration/TestPathMigrator.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +39,6 @@ public class TestPathMigrator extends TestPathBase {
     }
 
     private static PathMigrator migrator(Path path) {
-        return new PathMigrator(
-                path, StandardCopyOption.REPLACE_EXISTING, new PhotoResolver(List.of()));
+        return new PathMigrator(path, new PhotoResolver(List.of()));
     }
 }


### PR DESCRIPTION
Add Dropbox integration to Photohaul project since it seemed easy to play around with the official client:

https://github.com/dropbox/dropbox-sdk-java

In order for this to work as expected, you must follow the instructions here:

https://dropbox.tech/developers/generate-an-access-token-for-your-own-account

Then set the following values in `config.properties`:

- `source.root` - source path to visit photos on your local machine
- `target.root` - target path on Dropbox to upload photos to
- `dropbox.clientId` - anything that is memorable. One such example is "Photohaul/1.0"
- `dropbox.accessToken` - the access token generated from [the App Console](https://www.dropbox.com/developers/apps)

---

Logs:
```
10:12:51.702 [main] DEBUG io.huangsam.photohaul.traversal.PathTraversal -- Start traversal of ...
10:12:51.767 [main] DEBUG io.huangsam.photohaul.migration.DropboxMigrator -- Start DBX migration to /Demo
10:12:57.675 [main] INFO io.huangsam.photohaul.Main -- Finish with success=2 failure=0
```

Screenshot:
<img width="272" alt="dropbox-demo-ok" src="https://github.com/user-attachments/assets/5432cf54-eee2-4c0d-8e94-3213ef31b6e6">